### PR TITLE
Add XML-defined PDF watermark text background

### DIFF
--- a/django_advanced_pdf/pagers/base.py
+++ b/django_advanced_pdf/pagers/base.py
@@ -28,6 +28,7 @@ class BasePager(canvas.Canvas):
         self._saved_page_states = []
         self.test_mode = test_mode
         self.root_element = root_element
+        self.watermark = self.get_watermark_config()
 
         self.pageused = PageUsed(left=border_left_first,
                                  right=border_right_first,
@@ -48,6 +49,60 @@ class BasePager(canvas.Canvas):
 
         self.add_background_images()
 
+    @staticmethod
+    def get_float_value(value, default):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
+
+    def get_watermark_config(self):
+        if self.root_element is None:
+            return None
+
+        watermark_element = self.root_element.find('watermark')
+        if watermark_element is None:
+            return None
+
+        text = watermark_element.get('text')
+        if text is None:
+            text = watermark_element.text
+        if text is None:
+            return None
+
+        text = text.strip()
+        if text == '':
+            return None
+
+        font_name = watermark_element.get('font_name', 'Helvetica-Bold')
+        font_size = self.get_float_value(watermark_element.get('font_size'), 96)
+        if font_size <= 0:
+            font_size = 96
+
+        rotation = self.get_float_value(watermark_element.get('rotation'), 45)
+        opacity = self.get_float_value(watermark_element.get('opacity'), 0.2)
+        opacity = max(0.0, min(1.0, opacity))
+
+        colour = watermark_element.get('color', '#D3D3D3')
+        try:
+            fill_colour = colors.HexColor(colour)
+        except ValueError:
+            fill_colour = colors.HexColor('#D3D3D3')
+
+        page_scope = watermark_element.get('page', 'all').strip().lower()
+        if page_scope not in ('all', 'first', 'remaining'):
+            page_scope = 'all'
+
+        return {
+            'text': text,
+            'font_name': font_name,
+            'font_size': font_size,
+            'rotation': rotation,
+            'opacity': opacity,
+            'fill_colour': fill_colour,
+            'page_scope': page_scope
+        }
+
     def margins(self, first_page=True):
         return {'top': 0, 'bottom': 0, 'left': 0, 'right': 0}
 
@@ -55,9 +110,8 @@ class BasePager(canvas.Canvas):
         pass
 
     def add_background_images(self):
-        if self.background_image_first is not None or self.background_image_remaining is not None:
-            self.draw_first_page_background()
-            self.draw_footer_image_block()
+        self.draw_first_page_background()
+        self.draw_footer_image_block()
 
     def add_draw_method(self, method):
 
@@ -214,17 +268,42 @@ class BasePager(canvas.Canvas):
         if image is not None:
             self.drawImage(ImageReader(image), 0, 0, self.page_width(), self.page_height())
 
+    def draw_watermark(self, first_page):
+        if self.watermark is None:
+            return
+
+        page_scope = self.watermark['page_scope']
+        if page_scope == 'first' and not first_page:
+            return
+        if page_scope == 'remaining' and first_page:
+            return
+
+        self.saveState()
+        try:
+            set_fill_alpha = getattr(self, 'setFillAlpha', None)
+            if callable(set_fill_alpha):
+                set_fill_alpha(self.watermark['opacity'])
+            self.setFillColor(self.watermark['fill_colour'])
+            self.setFont(self.watermark['font_name'], self.watermark['font_size'])
+            self.translate(self.page_width() / 2.0, self.page_height() / 2.0)
+            self.rotate(self.watermark['rotation'])
+            self.drawCentredString(0, -self.watermark['font_size'] / 3.0, self.watermark['text'])
+        finally:
+            self.restoreState()
+
     def draw_first_page_background(self):
         """
         Adds the first page background image to the printout
         """
         self.draw_background(self.background_image_first)
+        self.draw_watermark(first_page=True)
 
     def draw_remaining_page_background(self):
         """
         Adds the background image for the remaining pages in the printout
         """
         self.draw_background(self.background_image_remaining)
+        self.draw_watermark(first_page=False)
 
     def draw_footer_image_block(self):
         """

--- a/django_advanced_pdf/tests.py
+++ b/django_advanced_pdf/tests.py
@@ -119,6 +119,23 @@ class PDFTests(unittest.TestCase):
     def test_label(self):
         self.run_report(name='label', object_lookup=self.get_sample_objects())
 
+    def test_watermark_from_xml(self):
+        xml = """
+        <document title="Watermark Test">
+            <watermark rotation="45" font_size="80">DRAFT</watermark>
+            <table>
+                <tr>
+                    <td>Hello world</td>
+                </tr>
+            </table>
+        </document>
+        """
+        report_xml = ReportXML(test_mode=True)
+        result = report_xml.load_xml_and_make_pdf(xml=xml)
+
+        with fitz.open("pdf", result) as doc:
+            self.assertIn("DRAFT", doc[0].get_text(), msg='Watermark text missing from generated PDF')
+
     @staticmethod
     def get_sample_objects():
         # Define the data for the table

--- a/django_advanced_pdf/tests.py
+++ b/django_advanced_pdf/tests.py
@@ -121,7 +121,7 @@ class PDFTests(unittest.TestCase):
 
     def test_watermark_from_xml(self):
         xml = """
-        <document title="Watermark Test">
+        <document title="Watermark Test" page_size="A4">
             <watermark rotation="45" font_size="80">DRAFT</watermark>
             <table>
                 <tr>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add support for XML-configured text watermark via a `<watermark>` element on the root document
- render watermark as part of page background drawing so it appears behind report content
- support optional watermark attributes: `text`, `font_name`, `font_size`, `rotation`, `opacity`, `color`, and `page` (`all|first|remaining`)
- add unit test `test_watermark_from_xml` that verifies watermark text is included in generated PDF output

## XML usage example
```xml
<document title="My Report" page_size="A4">
    <watermark font_size="80" rotation="45">DRAFT</watermark>
    <table>
        <tr><td>Hello world</td></tr>
    </table>
</document>
```

## Testing
- `python3 -m unittest django_advanced_pdf.tests.PDFTests.test_watermark_from_xml`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e56801c-9177-4beb-b097-b1807f45f768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e56801c-9177-4beb-b097-b1807f45f768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

